### PR TITLE
feat(driver): add Makefile to build motion_driver.ko

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,9 @@
+# Global ownership
+* @Amutai
+
+# Kernel driver code
+/driver/ @Amutai
+
+# Documentation
+/docs/ @Amutai
+*.md @Amutai

--- a/driver/Makefile
+++ b/driver/Makefile
@@ -1,0 +1,12 @@
+# driver/Makefile
+
+obj-m += motion_driver.o
+
+KDIR := /lib/modules/$(shell uname -r)/build
+PWD  := $(shell pwd)
+
+all:
+	$(MAKE) -C $(KDIR) M=$(PWD) modules
+
+clean:
+	$(MAKE) -C $(KDIR) M=$(PWD) clean


### PR DESCRIPTION
Closes #2

## What was done
- Configured build for motion_driver.o module
- Set kernel build directory and working path
- Included standard all and clean targets

## What's next
- Add skeleton `motion_driver.c` to implement init/exit module hooks
