### PR TITLE
fix(ci): improve TruffleHog secret scanning with dynamic base/head refs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,8 +105,8 @@ jobs:
       uses: trufflesecurity/trufflehog@main
       with:
         path: ./
-        base: main
-        head: HEAD
+        base: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
+        head: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.event.after }}
         
     - name: Kernel Security Analysis
       run: |


### PR DESCRIPTION
- Replace hardcoded 'main' and 'HEAD' with dynamic GitHub context variables
- Use pull_request.base.sha for PR base comparison
- Use github.event.before/after for push events
- Ensures proper diff scanning across different trigger events